### PR TITLE
declare intl dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
   "require": {
     "php": "^7.3 || ^8.0",
     "ext-json": "*",
+    "ext-intl": "*",
     "composer-plugin-api": "~1.0 || ~2.0"
   },
   "require-dev": {


### PR DESCRIPTION
seems this dependency is now mandatory but not declared

https://github.com/phpro/soap-client/pull/383#issuecomment-879122269